### PR TITLE
fix: add JsonElement support to OpenFeature provider

### DIFF
--- a/examples/OpenFeatureExample/Program.cs
+++ b/examples/OpenFeatureExample/Program.cs
@@ -56,10 +56,6 @@ try
     Console.WriteLine("\n🏗️  Demo 3: Structured Flag Evaluation");
     await DemoStructuredFlag(client, logger);
 
-    // Demo 4: Provider information
-    Console.WriteLine("\n📊 Demo 4: Provider Information");
-    await DemoProviderInfo(client, logger);
-
     Console.WriteLine("\n✅ All demos completed successfully!");
     return 0;
 }
@@ -170,33 +166,3 @@ static async Task DemoStructuredFlag(IFeatureClient client, ILogger logger)
     Console.WriteLine($"     Reason: {structureDetails.Reason}");
 }
 
-static async Task DemoProviderInfo(IFeatureClient client, ILogger logger)
-{
-    // Get provider metadata
-    var api = Api.Instance;
-    var providerMetadata = api.GetProviderMetadata();
-
-    Console.WriteLine($"  🔧 Provider Name: {providerMetadata?.Name ?? "Unknown"}");
-
-    // Show multiple evaluation with different contexts
-    var contexts = new[]
-    {
-        ("alice", EvaluationContext.Builder()
-            .SetTargetingKey("enabled_value_visitor")
-            .Set("visitor_id", "enabled_value_visitor")
-            .Set("user_type", "premium")
-            .Build()),
-        ("bob", EvaluationContext.Builder()
-            .SetTargetingKey("disabled_value_visitor")
-            .Set("visitor_id", "disabled_value_visitor")
-            .Set("user_type", "free")
-            .Build())
-    };
-
-    Console.WriteLine("  📈 Batch evaluation results:");
-    foreach (var (userName, context) in contexts)
-    {
-        var details = await client.GetBooleanDetailsAsync("hawkflag.enabled", false, context);
-        Console.WriteLine($"     {userName}: {details.Value} (reason: {details.Reason})");
-    }
-}

--- a/tests/Spotify.Confidence.OpenFeature.Tests/ConfidenceProviderTests.cs
+++ b/tests/Spotify.Confidence.OpenFeature.Tests/ConfidenceProviderTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Moq;
 using OpenFeature;
@@ -271,5 +272,134 @@ public class ConfidenceProviderTests
         Assert.NotNull(capturedContext);
         Assert.True(capturedContext!.Attributes.ContainsKey("targeting_key"));
         Assert.Equal(targetingKey, capturedContext.Attributes["targeting_key"]);
+    }
+
+    [Fact]
+    public async Task ResolveStructureValueAsync_WithJsonElementAllTypes_ReturnsCorrectValues()
+    {
+        // Arrange
+        const string flagKey = "test-flag";
+        var defaultStructure = Structure.Builder().Set("test", new Value("default")).Build();
+        var defaultValue = new Value(defaultStructure);
+        
+        var jsonDoc = JsonDocument.Parse(@"{
+            ""boolTrue"": true,
+            ""boolFalse"": false,
+            ""intValue"": 42,
+            ""doubleValue"": 3.14,
+            ""stringValue"": ""hello world"",
+            ""emptyString"": """",
+            ""nullValue"": null,
+            ""largeInteger"": 9007199254740991,
+            ""zero"": 0,
+            ""negative"": -42,
+            ""emptyObject"": {},
+            ""emptyArray"": [],
+            ""arrayValue"": [1, 2, 3, ""four""],
+            ""nested"": {
+                ""innerValue"": ""test"",
+                ""innerNumber"": 123
+            },
+            ""config"": {
+                ""enabled"": true,
+                ""threshold"": 50.5,
+                ""tags"": [""a"", ""b"", ""c""],
+                ""metadata"": {
+                    ""version"": ""1.0"",
+                    ""debug"": false
+                }
+            }
+        }");
+        
+        var resolvedObject = new Dictionary<string, object>();
+        foreach (var property in jsonDoc.RootElement.EnumerateObject())
+        {
+            resolvedObject[property.Name] = property.Value;
+        }
+        
+        const string variant = "test-variant";
+
+        _mockClient.Setup(c => c.EvaluateJsonFlagAsync(flagKey, It.IsAny<object>(), It.IsAny<ConfidenceContext>(), default))
+            .ReturnsAsync(new EvaluationResult<object>
+            {
+                Value = resolvedObject,
+                Variant = variant,
+                Reason = "TARGETING_MATCH"
+            });
+
+        // Act
+        var result = await _provider.ResolveStructureValueAsync(flagKey, defaultValue);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Value.AsStructure);
+        Assert.Equal(flagKey, result.FlagKey);
+        Assert.Equal(variant, result.Variant);
+        Assert.Equal("TARGETING_MATCH", result.Reason);
+        
+        var structure = result.Value.AsStructure!;
+        
+        // Boolean values
+        Assert.True(structure.GetValue("boolTrue").AsBoolean);
+        Assert.False(structure.GetValue("boolFalse").AsBoolean);
+        
+        // Numeric values
+        Assert.Equal(42, structure.GetValue("intValue").AsInteger);
+        Assert.Equal(3.14, structure.GetValue("doubleValue").AsDouble);
+        Assert.Equal(0, structure.GetValue("zero").AsInteger);
+        Assert.Equal(-42, structure.GetValue("negative").AsInteger);
+        // Large integers should be handled as doubles since they don't fit in int32
+        Assert.Equal(9007199254740991.0, structure.GetValue("largeInteger").AsDouble);
+        
+        // String values
+        Assert.Equal("hello world", structure.GetValue("stringValue").AsString);
+        Assert.Equal("", structure.GetValue("emptyString").AsString);
+        
+        // Null value
+        Assert.True(structure.GetValue("nullValue").IsNull);
+        
+        // Empty containers
+        var emptyObject = structure.GetValue("emptyObject").AsStructure;
+        Assert.NotNull(emptyObject);
+        Assert.Equal(0, emptyObject!.Count);
+        
+        var emptyArray = structure.GetValue("emptyArray").AsList;
+        Assert.NotNull(emptyArray);
+        Assert.Empty(emptyArray!);
+        
+        // Array with mixed types
+        var arrayValue = structure.GetValue("arrayValue").AsList;
+        Assert.NotNull(arrayValue);
+        Assert.Equal(4, arrayValue!.Count);
+        Assert.Equal(1, arrayValue[0].AsInteger);
+        Assert.Equal(2, arrayValue[1].AsInteger);
+        Assert.Equal(3, arrayValue[2].AsInteger);
+        Assert.Equal("four", arrayValue[3].AsString);
+        
+        // Nested object
+        var nestedStructure = structure.GetValue("nested").AsStructure;
+        Assert.NotNull(nestedStructure);
+        Assert.Equal("test", nestedStructure!.GetValue("innerValue").AsString);
+        Assert.Equal(123, nestedStructure.GetValue("innerNumber").AsInteger);
+        
+        // Complex nested structure
+        var config = structure.GetValue("config").AsStructure;
+        Assert.NotNull(config);
+        Assert.True(config!.GetValue("enabled").AsBoolean);
+        Assert.Equal(50.5, config.GetValue("threshold").AsDouble);
+        
+        var tags = config.GetValue("tags").AsList;
+        Assert.NotNull(tags);
+        Assert.Equal(3, tags!.Count);
+        Assert.Equal("a", tags[0].AsString);
+        Assert.Equal("b", tags[1].AsString);
+        Assert.Equal("c", tags[2].AsString);
+        
+        var metadata = config.GetValue("metadata").AsStructure;
+        Assert.NotNull(metadata);
+        Assert.Equal("1.0", metadata!.GetValue("version").AsString);
+        Assert.False(metadata.GetValue("debug").AsBoolean);
+        
+        jsonDoc.Dispose();
     }
 }


### PR DESCRIPTION
- Add handling for System.Text.Json.JsonElement in ConvertToValue method
- Implement ConvertJsonElementToValue for proper type conversion
- Implement ConvertJsonObjectToStructure for nested object handling
- Add System.Text.Json and System.Linq using statements
- Fixes OpenFeature provider returning default values on successful API responses
