### PR TITLE
fix: Correct meta file for Unity SDK

### DIFF
--- a/unity-sdk/README.md
+++ b/unity-sdk/README.md
@@ -45,7 +45,8 @@ unity-sdk/
    ```json
    {
      "dependencies": {
-       "com.unity.openfeature": "file:../path/to/unity-sdk"
+       "com.unity.openfeature": "file:../path/to/unity-sdk",
+       "com.unity.modules.unitywebrequest": "1.0.0"
      }
    }
    ```
@@ -67,6 +68,7 @@ unity-sdk/
 
 - Unity 2020.3+
 - com.unity.nuget.newtonsoft-json: 3.0.2
+- UnityWebRequest 1.0.0 (Builtin)
 
 
 ## Compile check

--- a/unity-sdk/Runtime.meta
+++ b/unity-sdk/Runtime.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a1b2c3d4e5f6789012345678901234567890abcd
+guid: 3f701c2665bc842739841a9cff2d0473
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}


### PR DESCRIPTION
When importing the `unity-sdk` into a Unity project, developers get this message:
<img width="648" height="353" alt="Screenshot 2025-09-15 at 09 51 17" src="https://github.com/user-attachments/assets/b3610091-8933-44c7-b2f9-a975f85d489f" />

Which is caused by the Runtime folder's meta file not having a proper GUID set. This PR fixes that issue.

It also includes a mention to a built-in dependency. This package is not included by default in all Unity projects, so it is helpful to have it mentioned.