### PR TITLE
IFeatureProvider exposes an OnReady event

### DIFF
--- a/unity-sdk/Runtime/Core/IFeatureProvider.cs
+++ b/unity-sdk/Runtime/Core/IFeatureProvider.cs
@@ -14,6 +14,8 @@ namespace UnityOpenFeature.Core
         void Initialize(Action<bool, string> callback = null);
         void OnContextSet(EvaluationContext oldContext, EvaluationContext newContext, Action<bool, string> callback = null);
         void Shutdown();
+
+        event Action OnReady;
     }
 }
 

--- a/unity-sdk/Runtime/Providers/ConfidenceProvider.cs
+++ b/unity-sdk/Runtime/Providers/ConfidenceProvider.cs
@@ -16,6 +16,8 @@ namespace UnityOpenFeature.Providers
         public string Name => "ConfidenceProvider";
         public bool IsReady { get; private set; }
 
+        public event Action OnReady;
+
         [SerializeField] private string clientSecret;
         private ConfidenceApiClient apiClient;
 
@@ -112,6 +114,7 @@ namespace UnityOpenFeature.Providers
             FetchAndActivate((success, error) =>
             {
                 IsReady = success;
+                OnReady?.Invoke();
                 callback?.Invoke(success, error);
                 if (success)
                 {

--- a/unity-sdk/Runtime/Providers/InMemoryProvider.cs
+++ b/unity-sdk/Runtime/Providers/InMemoryProvider.cs
@@ -11,6 +11,8 @@ namespace UnityOpenFeature.Providers
         public string Name => "InMemoryProvider";
         public bool IsReady { get; private set; }
 
+        public event Action OnReady;
+
         [SerializeField] private List<FeatureFlag> flags = new List<FeatureFlag>();
         private Dictionary<string, object> flagDictionary = new Dictionary<string, object>();
 
@@ -27,6 +29,7 @@ namespace UnityOpenFeature.Providers
         {
             InitializeDictionary();
             IsReady = true;
+            OnReady?.Invoke();
             callback?.Invoke(true, "InMemoryProvider initialized");
             Debug.Log($"InMemoryProvider initialized with {flags.Count} flags");
         }


### PR DESCRIPTION
Based on a conversation we had, adding this functionality allows client applications to set up a listener which resolves when a provider has become ready.