### PR TITLE
feat: align Unity SDK with OpenFeature static-context paradigm

### DIFF
--- a/unity-sdk/Runtime/Client/FeatureClient.cs
+++ b/unity-sdk/Runtime/Client/FeatureClient.cs
@@ -14,66 +14,59 @@ namespace UnityOpenFeature.Client
             this.domain = domain;
         }
 
-        public bool GetBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null)
+        public bool GetBooleanValue(string flagKey, bool defaultValue)
         {
-            return GetBooleanDetails(flagKey, defaultValue, context).Value;
+            return GetBooleanDetails(flagKey, defaultValue).Value;
         }
 
-        public string GetStringValue(string flagKey, string defaultValue, EvaluationContext context = null)
+        public string GetStringValue(string flagKey, string defaultValue)
         {
-            return GetStringDetails(flagKey, defaultValue, context).Value;
+            return GetStringDetails(flagKey, defaultValue).Value;
         }
 
-        public int GetIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null)
+        public int GetIntegerValue(string flagKey, int defaultValue)
         {
-            return GetIntegerDetails(flagKey, defaultValue, context).Value;
+            return GetIntegerDetails(flagKey, defaultValue).Value;
         }
 
-        public float GetFloatValue(string flagKey, float defaultValue, EvaluationContext context = null)
+        public float GetFloatValue(string flagKey, float defaultValue)
         {
-            return GetFloatDetails(flagKey, defaultValue, context).Value;
+            return GetFloatDetails(flagKey, defaultValue).Value;
         }
 
-        public T GetObjectValue<T>(string flagKey, T defaultValue, EvaluationContext context = null)
+        public T GetObjectValue<T>(string flagKey, T defaultValue)
         {
-            return GetObjectDetails(flagKey, defaultValue, context).Value;
+            return GetObjectDetails(flagKey, defaultValue).Value;
         }
 
-        public ResolutionDetails<bool> GetBooleanDetails(string flagKey, bool defaultValue, EvaluationContext context = null)
+        public ResolutionDetails<bool> GetBooleanDetails(string flagKey, bool defaultValue)
         {
             if (api.Provider == null) { Debug.LogWarning("No provider set"); return ResolutionDetails<bool>.Error(flagKey, defaultValue, ErrorCode.ProviderNotReady, "No provider"); }
             return api.Provider.ResolveBooleanValue(flagKey, defaultValue);
         }
 
-        public ResolutionDetails<string> GetStringDetails(string flagKey, string defaultValue, EvaluationContext context = null)
+        public ResolutionDetails<string> GetStringDetails(string flagKey, string defaultValue)
         {
             if (api.Provider == null) { Debug.LogWarning("No provider set"); return ResolutionDetails<string>.Error(flagKey, defaultValue, ErrorCode.ProviderNotReady, "No provider"); }
             return api.Provider.ResolveStringValue(flagKey, defaultValue);
         }
 
-        public ResolutionDetails<int> GetIntegerDetails(string flagKey, int defaultValue, EvaluationContext context = null)
+        public ResolutionDetails<int> GetIntegerDetails(string flagKey, int defaultValue)
         {
             if (api.Provider == null) { Debug.LogWarning("No provider set"); return ResolutionDetails<int>.Error(flagKey, defaultValue, ErrorCode.ProviderNotReady, "No provider"); }
             return api.Provider.ResolveIntegerValue(flagKey, defaultValue);
         }
 
-        public ResolutionDetails<float> GetFloatDetails(string flagKey, float defaultValue, EvaluationContext context = null)
+        public ResolutionDetails<float> GetFloatDetails(string flagKey, float defaultValue)
         {
             if (api.Provider == null) { Debug.LogWarning("No provider set"); return ResolutionDetails<float>.Error(flagKey, defaultValue, ErrorCode.ProviderNotReady, "No provider"); }
             return api.Provider.ResolveFloatValue(flagKey, defaultValue);
         }
 
-        public ResolutionDetails<T> GetObjectDetails<T>(string flagKey, T defaultValue, EvaluationContext context = null)
+        public ResolutionDetails<T> GetObjectDetails<T>(string flagKey, T defaultValue)
         {
             if (api.Provider == null) { Debug.LogWarning("No provider set"); return ResolutionDetails<T>.Error(flagKey, defaultValue, ErrorCode.ProviderNotReady, "No provider"); }
             return api.Provider.ResolveObjectValue<T>(flagKey, defaultValue);
-        }
-
-        private EvaluationContext MergeContext(EvaluationContext requestContext)
-        {
-            var merged = new EvaluationContext(api.EvaluationContext.TargetingKey);
-            if (requestContext != null) merged.TargetingKey = requestContext.TargetingKey;
-            return merged;
         }
     }
 }

--- a/unity-sdk/Runtime/Client/IFeatureClient.cs
+++ b/unity-sdk/Runtime/Client/IFeatureClient.cs
@@ -4,17 +4,17 @@ namespace UnityOpenFeature.Client
 {
     public interface IFeatureClient
     {
-        bool GetBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null);
-        string GetStringValue(string flagKey, string defaultValue, EvaluationContext context = null);
-        int GetIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null);
-        float GetFloatValue(string flagKey, float defaultValue, EvaluationContext context = null);
-        T GetObjectValue<T>(string flagKey, T defaultValue, EvaluationContext context = null);
-        
-        ResolutionDetails<bool> GetBooleanDetails(string flagKey, bool defaultValue, EvaluationContext context = null);
-        ResolutionDetails<string> GetStringDetails(string flagKey, string defaultValue, EvaluationContext context = null);
-        ResolutionDetails<int> GetIntegerDetails(string flagKey, int defaultValue, EvaluationContext context = null);
-        ResolutionDetails<float> GetFloatDetails(string flagKey, float defaultValue, EvaluationContext context = null);
-        ResolutionDetails<T> GetObjectDetails<T>(string flagKey, T defaultValue, EvaluationContext context = null);
+        bool GetBooleanValue(string flagKey, bool defaultValue);
+        string GetStringValue(string flagKey, string defaultValue);
+        int GetIntegerValue(string flagKey, int defaultValue);
+        float GetFloatValue(string flagKey, float defaultValue);
+        T GetObjectValue<T>(string flagKey, T defaultValue);
+
+        ResolutionDetails<bool> GetBooleanDetails(string flagKey, bool defaultValue);
+        ResolutionDetails<string> GetStringDetails(string flagKey, string defaultValue);
+        ResolutionDetails<int> GetIntegerDetails(string flagKey, int defaultValue);
+        ResolutionDetails<float> GetFloatDetails(string flagKey, float defaultValue);
+        ResolutionDetails<T> GetObjectDetails<T>(string flagKey, T defaultValue);
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove per-evaluation context parameters from `IFeatureClient` methods
- Update `FeatureClient` implementation to match the interface
- Remove unused `MergeContext` method

## Context
This aligns the Unity SDK with the [OpenFeature static-context paradigm specification](https://openfeature.dev/specification/glossary#static-context-paradigm).

In the static-context paradigm (used for client-side applications like Unity games):
- Evaluation context is set globally at the API level via `SetEvaluationContext()`
- Flag evaluation methods do not accept per-evaluation context
- Context changes trigger provider reconciliation via `OnContextSet()`

## Changes
**Before:**
```csharp
client.GetBooleanValue("flag-key", false, context);
```

**After:**
```csharp
api.SetEvaluationContext(context);
client.GetBooleanValue("flag-key", false);
```

## Test plan
- [ ] Verify Unity SDK builds without errors
- [ ] Test that flag evaluations work with globally set context
- [ ] Confirm provider `OnContextSet` is called when context changes
- [ ] Check that existing Unity examples still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)