### PR TITLE
chore: include unity-sdk package.json in release-please versioning

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,12 @@
         "README.md",
         "src/Spotify.Confidence.Sdk/Spotify.Confidence.Sdk.csproj",
         "src/Spotify.Confidence.OpenFeature/Spotify.Confidence.OpenFeature.csproj",
-        "tests/Spotify.Confidence.Sdk.Tests/ConfidenceClientTests.cs"
+        "tests/Spotify.Confidence.Sdk.Tests/ConfidenceClientTests.cs",
+        {
+          "type": "json",
+          "path": "unity-sdk/package.json",
+          "jsonpath": "$.version"
+        }
       ]
     }
   },

--- a/unity-sdk/package.json
+++ b/unity-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.openfeature",
-  "version": "1.0.0",
+  "version": "0.2.2",
   "displayName": "Unity OpenFeature SDK",
   "description": "Unity-compatible OpenFeature SDK for feature flag management",
   "unity": "2020.3",


### PR DESCRIPTION
## Summary
- Adds `unity-sdk/package.json` to release-please `extra-files` with jsonpath targeting `$.version`
- Syncs `package.json` version from `1.0.0` to `0.2.2` to match current release
- Future releases will automatically keep the UPM package version in sync with the NuGet packages

## Verification
Verified using `release-please --dry-run` against this branch. Temporarily changed the commit type to `fix:` to trigger a release candidate, and confirmed release-please:
- Fetched `unity-sdk/package.json` from the branch
- Applied the `GenericJson` updater (jsonpath handler)
- Included it in the list of 8 files to update for a `0.2.3` release

```
❯ Fetching unity-sdk/package.json from branch nicklasl/chore-release-please-unity-version
  unity-sdk/package.json:  [class GenericJson]
```

## Test plan
- [x] Dry-run `release-please release-pr` against this branch with a `fix:` commit — confirms `unity-sdk/package.json` is picked up and versioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)