### PR TITLE
feat(unity): add telemetry to Unity SDK

### DIFF
--- a/unity-sdk/Runtime/Providers/ConfidenceApiClient.cs
+++ b/unity-sdk/Runtime/Providers/ConfidenceApiClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -9,7 +10,9 @@ using UnityEngine.Networking;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using UnityEngine.Scripting;
+using UnityOpenFeature.Telemetry;
 using Object = UnityEngine.Object;
+using Debug = UnityEngine.Debug;
 
 namespace UnityOpenFeature.Providers
 {
@@ -41,6 +44,9 @@ namespace UnityOpenFeature.Providers
         private float checkpointTimer = 0f;
         private const float CHECKPOINT_INTERVAL = 10f; // 10 seconds
 
+        private const string TelemetryHeaderName = "X-CONFIDENCE-TELEMETRY";
+        internal Telemetry.Telemetry Telemetry { get; private set; }
+
         // Private constructor - use Create() method instead
         private ConfidenceApiClient() { }
     
@@ -53,6 +59,7 @@ namespace UnityOpenFeature.Providers
             // Add the client as a component
             ConfidenceApiClient client = clientGO.AddComponent<ConfidenceApiClient>();
             client.clientSecret = clientSecret;
+            client.Telemetry = new Telemetry.Telemetry(Platform.DotNet, client.sdkVersion);
 
             return client;
         }
@@ -103,12 +110,32 @@ namespace UnityOpenFeature.Providers
             };
 
             string jsonBody = JsonConvert.SerializeObject(requestBody);
+            var stopwatch = Stopwatch.StartNew();
+            RequestStatus resolveStatus = RequestStatus.Ok;
 
             using (UnityWebRequest request = new UnityWebRequest(url, "POST"))
             {
                 // Set headers
                 request.SetRequestHeader("Content-Type", "application/json");
                 request.SetRequestHeader("Accept", "application/json");
+
+                // Attach telemetry header
+                try
+                {
+                    if (Telemetry != null)
+                    {
+                        var headerValue = Telemetry.EncodedHeaderValue();
+                        if (headerValue != null)
+                        {
+                            request.SetRequestHeader(TelemetryHeaderName, headerValue);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.Log($"Telemetry header error (best-effort): {ex.Message}");
+                }
+
                 request.downloadHandler = new DownloadHandlerBuffer();
 
                 // Set upload handler with JSON body
@@ -119,6 +146,8 @@ namespace UnityOpenFeature.Providers
                 {
                     await Task.Delay(100); // Small delay to prevent busy waiting
                 }
+
+                stopwatch.Stop();
 
                 if (request.result == UnityWebRequest.Result.Success)
                 {
@@ -133,14 +162,26 @@ namespace UnityOpenFeature.Providers
                     }
                     catch (Exception ex)
                     {
+                        resolveStatus = RequestStatus.Error;
                         callback?.Invoke(null, $"Failed to parse response: {ex.Message}");
                     }
                 }
                 else
                 {
+                    resolveStatus = RequestStatus.Error;
                     string errorMsg = $"Network request failed: {request.error}";
                     callback?.Invoke(null, errorMsg);
                 }
+            }
+
+            // Track resolve latency (best-effort)
+            try
+            {
+                Telemetry?.TrackResolveLatency((ulong)stopwatch.ElapsedMilliseconds, resolveStatus);
+            }
+            catch (Exception ex)
+            {
+                Debug.Log($"Telemetry latency tracking error (best-effort): {ex.Message}");
             }
         }
 

--- a/unity-sdk/Runtime/Providers/ConfidenceProvider.cs
+++ b/unity-sdk/Runtime/Providers/ConfidenceProvider.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 using UnityEngine.Networking;
 using Newtonsoft.Json;
 using UnityOpenFeature.Core;
+using UnityOpenFeature.Telemetry;
 
 namespace UnityOpenFeature.Providers
 {
@@ -294,7 +295,11 @@ namespace UnityOpenFeature.Providers
         {
             var value = ResolveValueByDotNotation(flagKey);
             if (value == null)
-                return ResolutionDetails<T>.Error(flagKey, defaultValue, ErrorCode.FlagNotFound, $"Flag '{flagKey}' not found");
+            {
+                var errorResult = ResolutionDetails<T>.Error(flagKey, defaultValue, ErrorCode.FlagNotFound, $"Flag '{flagKey}' not found");
+                TrackEvaluation(null, errorResult.ErrorMessage);
+                return errorResult;
+            }
 
             var rootFlagKey = flagKey.Split('.')[0];
             var resolvedFlag = GetResolvedFlag(rootFlagKey);
@@ -315,6 +320,8 @@ namespace UnityOpenFeature.Providers
             catch (Exception ex)
             {
                 details = ResolutionDetails<T>.Error(flagKey, defaultValue, ErrorCode.ParseError, $"Cannot parse: {ex.Message}");
+                TrackEvaluation(resolvedFlag?.reason, details.ErrorMessage);
+                return details;
             }
 
             if (resolvedFlag != null)
@@ -325,6 +332,7 @@ namespace UnityOpenFeature.Providers
                 tryApply(resolvedFlag, rootFlagKey);
             }
 
+            TrackEvaluation(resolvedFlag?.reason, null);
             return details;
         }
 
@@ -395,6 +403,22 @@ namespace UnityOpenFeature.Providers
                 "ERROR" => UnityOpenFeature.Core.Reason.ERROR,
                 _ => UnityOpenFeature.Core.Reason.RESOLVE_REASON_UNSPECIFIED
             };
+        }
+
+        private void TrackEvaluation(string apiReason, string errorMessage)
+        {
+            try
+            {
+                if (apiClient?.Telemetry != null)
+                {
+                    var (reason, errorCode) = Telemetry.Telemetry.MapEvaluationReason(apiReason, errorMessage);
+                    apiClient.Telemetry.TrackEvaluation(reason, errorCode);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.Log($"Telemetry eval tracking error (best-effort): {ex.Message}");
+            }
         }
 
         private Dictionary<string, object> GetEvaluationContext()

--- a/unity-sdk/Runtime/Telemetry/ProtobufEncoder.cs
+++ b/unity-sdk/Runtime/Telemetry/ProtobufEncoder.cs
@@ -1,0 +1,175 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace UnityOpenFeature.Telemetry
+{
+    internal static class ProtobufEncoder
+    {
+        private const int WireTypeVarint = 0;
+        private const int WireTypeLengthDelimited = 2;
+
+        public static byte[] EncodeMonitoring(
+            Library library,
+            string sdkVersion,
+            Platform platform,
+            IReadOnlyList<ResolveLatencyTraceData> resolveTraces,
+            IReadOnlyList<EvaluationTraceData> evalTraces)
+        {
+            using (var ms = new MemoryStream())
+            {
+                var libraryTracesBytes = EncodeLibraryTraces(library, sdkVersion, resolveTraces, evalTraces);
+                if (libraryTracesBytes.Length > 0)
+                {
+                    WriteLengthDelimited(ms, 1, libraryTracesBytes);
+                }
+
+                if (platform != Platform.Unspecified)
+                {
+                    WriteTag(ms, 2, WireTypeVarint);
+                    WriteVarint(ms, (ulong)platform);
+                }
+
+                return ms.ToArray();
+            }
+        }
+
+        private static byte[] EncodeLibraryTraces(
+            Library library,
+            string sdkVersion,
+            IReadOnlyList<ResolveLatencyTraceData> resolveTraces,
+            IReadOnlyList<EvaluationTraceData> evalTraces)
+        {
+            using (var ms = new MemoryStream())
+            {
+                if (library != Library.Unspecified)
+                {
+                    WriteTag(ms, 1, WireTypeVarint);
+                    WriteVarint(ms, (ulong)library);
+                }
+
+                if (!string.IsNullOrEmpty(sdkVersion))
+                {
+                    var versionBytes = Encoding.UTF8.GetBytes(sdkVersion);
+                    WriteLengthDelimited(ms, 2, versionBytes);
+                }
+
+                foreach (var trace in resolveTraces)
+                {
+                    var traceBytes = EncodeResolveTrace(trace);
+                    WriteLengthDelimited(ms, 3, traceBytes);
+                }
+
+                foreach (var trace in evalTraces)
+                {
+                    var traceBytes = EncodeEvaluationTrace(trace);
+                    WriteLengthDelimited(ms, 3, traceBytes);
+                }
+
+                return ms.ToArray();
+            }
+        }
+
+        private static byte[] EncodeResolveTrace(ResolveLatencyTraceData data)
+        {
+            using (var ms = new MemoryStream())
+            {
+                WriteTag(ms, 1, WireTypeVarint);
+                WriteVarint(ms, (ulong)TraceId.ResolveLatency);
+
+                var requestTraceBytes = EncodeRequestTrace(data);
+                if (requestTraceBytes.Length > 0)
+                {
+                    WriteLengthDelimited(ms, 3, requestTraceBytes);
+                }
+
+                return ms.ToArray();
+            }
+        }
+
+        private static byte[] EncodeRequestTrace(ResolveLatencyTraceData data)
+        {
+            using (var ms = new MemoryStream())
+            {
+                if (data.MillisecondDuration > 0)
+                {
+                    WriteTag(ms, 1, WireTypeVarint);
+                    WriteVarint(ms, data.MillisecondDuration);
+                }
+
+                if (data.Status != RequestStatus.Unspecified)
+                {
+                    WriteTag(ms, 2, WireTypeVarint);
+                    WriteVarint(ms, (ulong)data.Status);
+                }
+
+                return ms.ToArray();
+            }
+        }
+
+        private static byte[] EncodeEvaluationTrace(EvaluationTraceData data)
+        {
+            using (var ms = new MemoryStream())
+            {
+                WriteTag(ms, 1, WireTypeVarint);
+                WriteVarint(ms, (ulong)TraceId.EvaluationOutcome);
+
+                var evalTraceBytes = EncodeEvalTraceBody(data);
+                if (evalTraceBytes.Length > 0)
+                {
+                    WriteLengthDelimited(ms, 5, evalTraceBytes);
+                }
+
+                return ms.ToArray();
+            }
+        }
+
+        private static byte[] EncodeEvalTraceBody(EvaluationTraceData data)
+        {
+            using (var ms = new MemoryStream())
+            {
+                if (data.Reason != EvaluationReason.Unspecified)
+                {
+                    WriteTag(ms, 1, WireTypeVarint);
+                    WriteVarint(ms, (ulong)data.Reason);
+                }
+
+                if (data.ErrorCode != EvaluationErrorCode.Unspecified)
+                {
+                    WriteTag(ms, 2, WireTypeVarint);
+                    WriteVarint(ms, (ulong)data.ErrorCode);
+                }
+
+                return ms.ToArray();
+            }
+        }
+
+        private static void WriteTag(Stream stream, int fieldNumber, int wireType)
+        {
+            WriteVarint(stream, (ulong)((fieldNumber << 3) | wireType));
+        }
+
+        private static void WriteVarint(Stream stream, ulong value)
+        {
+            do
+            {
+                var b = (byte)(value & 0x7F);
+                value >>= 7;
+                if (value != 0)
+                {
+                    b |= 0x80;
+                }
+
+                stream.WriteByte(b);
+            }
+            while (value != 0);
+        }
+
+        private static void WriteLengthDelimited(Stream stream, int fieldNumber, byte[] data)
+        {
+            WriteTag(stream, fieldNumber, WireTypeLengthDelimited);
+            WriteVarint(stream, (ulong)data.Length);
+            stream.Write(data, 0, data.Length);
+        }
+    }
+}

--- a/unity-sdk/Runtime/Telemetry/Telemetry.cs
+++ b/unity-sdk/Runtime/Telemetry/Telemetry.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+
+namespace UnityOpenFeature.Telemetry
+{
+    internal class EvaluationTraceData
+    {
+        public EvaluationReason Reason { get; }
+        public EvaluationErrorCode ErrorCode { get; }
+
+        public EvaluationTraceData(EvaluationReason reason, EvaluationErrorCode errorCode)
+        {
+            Reason = reason;
+            ErrorCode = errorCode;
+        }
+    }
+
+    internal class ResolveLatencyTraceData
+    {
+        public ulong MillisecondDuration { get; }
+        public RequestStatus Status { get; }
+
+        public ResolveLatencyTraceData(ulong millisecondDuration, RequestStatus status)
+        {
+            MillisecondDuration = millisecondDuration;
+            Status = status;
+        }
+    }
+
+    internal sealed class Telemetry
+    {
+        private const int MaxTraces = 100;
+
+        private readonly object _lock = new object();
+        private readonly Platform _platform;
+        private readonly string _sdkVersion;
+        private List<EvaluationTraceData> _evalTraces = new List<EvaluationTraceData>();
+        private List<ResolveLatencyTraceData> _resolveTraces = new List<ResolveLatencyTraceData>();
+        private volatile Library _currentLibrary = Library.OpenFeature;
+
+        internal Library CurrentLibrary
+        {
+            get { return _currentLibrary; }
+            set { _currentLibrary = value; }
+        }
+
+        internal Telemetry(Platform platform, string sdkVersion)
+        {
+            _platform = platform;
+            _sdkVersion = sdkVersion;
+        }
+
+        internal void TrackEvaluation(EvaluationReason reason, EvaluationErrorCode errorCode)
+        {
+            lock (_lock)
+            {
+                if (_evalTraces.Count < MaxTraces)
+                {
+                    _evalTraces.Add(new EvaluationTraceData(reason, errorCode));
+                }
+            }
+        }
+
+        internal void TrackResolveLatency(ulong durationMs, RequestStatus status)
+        {
+            lock (_lock)
+            {
+                if (_resolveTraces.Count < MaxTraces)
+                {
+                    _resolveTraces.Add(new ResolveLatencyTraceData(durationMs, status));
+                }
+            }
+        }
+
+        internal string EncodedHeaderValue()
+        {
+            List<EvaluationTraceData> evalSnapshot;
+            List<ResolveLatencyTraceData> resolveSnapshot;
+
+            lock (_lock)
+            {
+                if (_evalTraces.Count == 0 && _resolveTraces.Count == 0)
+                {
+                    return null;
+                }
+
+                evalSnapshot = _evalTraces;
+                resolveSnapshot = _resolveTraces;
+                _evalTraces = new List<EvaluationTraceData>();
+                _resolveTraces = new List<ResolveLatencyTraceData>();
+            }
+
+            var bytes = ProtobufEncoder.EncodeMonitoring(
+                _currentLibrary,
+                _sdkVersion,
+                _platform,
+                resolveSnapshot,
+                evalSnapshot);
+
+            return Convert.ToBase64String(bytes);
+        }
+
+        internal static (EvaluationReason reason, EvaluationErrorCode errorCode) MapEvaluationReason(
+            string apiReason,
+            string errorMessage)
+        {
+            if (errorMessage != null)
+            {
+                var errorCode = MapErrorMessageToCode(errorMessage);
+                return (EvaluationReason.Error, errorCode);
+            }
+
+            EvaluationReason reason;
+            switch (apiReason)
+            {
+                case "RESOLVE_REASON_MATCH":
+                    reason = EvaluationReason.Match;
+                    break;
+                case "RESOLVE_REASON_UNSPECIFIED":
+                    reason = EvaluationReason.Unspecified_;
+                    break;
+                case "RESOLVE_REASON_NO_SEGMENT_MATCH":
+                case "RESOLVE_REASON_NO_TREATMENT_MATCH":
+                    reason = EvaluationReason.NoSegmentMatch;
+                    break;
+                case "RESOLVE_REASON_FLAG_ARCHIVED":
+                    reason = EvaluationReason.Archived;
+                    break;
+                case "RESOLVE_REASON_TARGETING_KEY_ERROR":
+                    reason = EvaluationReason.TargetingKeyError;
+                    break;
+                case "ERROR":
+                    reason = EvaluationReason.Error;
+                    break;
+                default:
+                    reason = EvaluationReason.Unspecified;
+                    break;
+            }
+
+            return (reason, EvaluationErrorCode.Unspecified);
+        }
+
+        private static EvaluationErrorCode MapErrorMessageToCode(string errorMessage)
+        {
+            var lower = errorMessage.ToLowerInvariant();
+
+            if (lower.Contains("not found"))
+                return EvaluationErrorCode.FlagNotFound;
+
+            if (lower.Contains("parse") || lower.Contains("type mismatch") || lower.Contains("cannot convert"))
+                return EvaluationErrorCode.ParseError;
+
+            return EvaluationErrorCode.GeneralError;
+        }
+    }
+}

--- a/unity-sdk/Runtime/Telemetry/TelemetryEnums.cs
+++ b/unity-sdk/Runtime/Telemetry/TelemetryEnums.cs
@@ -1,0 +1,55 @@
+namespace UnityOpenFeature.Telemetry
+{
+    internal enum Platform
+    {
+        Unspecified = 0,
+        DotNet = 12,
+    }
+
+    internal enum Library
+    {
+        Unspecified = 0,
+        Confidence = 1,
+        OpenFeature = 2,
+    }
+
+    internal enum TraceId
+    {
+        Unspecified = 0,
+        ResolveLatency = 1,
+        EvaluationOutcome = 2,
+    }
+
+    internal enum RequestStatus
+    {
+        Unspecified = 0,
+        Ok = 1,
+        Timeout = 2,
+        Error = 3,
+    }
+
+    internal enum EvaluationReason
+    {
+        Unspecified = 0,
+        Match = 1,
+        Unspecified_ = 2,
+        NoSegmentMatch = 3,
+        Archived = 4,
+        TargetingKeyError = 5,
+        ProviderNotReady = 6,
+        DefaultValue = 7,
+        Error = 8,
+    }
+
+    internal enum EvaluationErrorCode
+    {
+        Unspecified = 0,
+        ProviderNotReady = 1,
+        FlagNotFound = 2,
+        ParseError = 3,
+        TypeMismatch = 4,
+        GeneralError = 5,
+        InvalidContext = 6,
+        TargetingKeyMissing = 7,
+    }
+}


### PR DESCRIPTION
## Summary
- Add SDK telemetry to the Unity SDK, tracking resolve latency and evaluation outcomes
- Sent via `X-CONFIDENCE-TELEMETRY` header on resolve requests using manual protobuf encoding
- Thread-safe trace accumulation with snapshot-and-clear, capped at 100 traces per type
- All telemetry code guarded with try/catch — telemetry errors never affect SDK functionality
- Mirrors the telemetry implementation from the main .NET SDK (PR #38)

## Changes
- **New**: `Runtime/Telemetry/TelemetryEnums.cs` — protobuf enum types
- **New**: `Runtime/Telemetry/ProtobufEncoder.cs` — manual wire-format encoder
- **New**: `Runtime/Telemetry/Telemetry.cs` — trace accumulation, encoding, reason mapping
- **Modified**: `ConfidenceApiClient.cs` — attach header on resolve, track latency via Stopwatch
- **Modified**: `ConfidenceProvider.cs` — track evaluation outcomes in ResolveObjectValue

## Test plan
- [ ] Unity build test passes (`build-test.sh`)
- [ ] Resolve requests include `X-CONFIDENCE-TELEMETRY` header after first call
- [ ] Event/apply requests do NOT include telemetry header
- [ ] Telemetry errors do not propagate to callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)