### PR TITLE
ci: declare minimum permissions on workflow files

### DIFF
--- a/.github/workflows/lint-pr-name.yaml
+++ b/.github/workflows/lint-pr-name.yaml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   main:
     name: Validate PR title

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds explicit workflow-level `permissions:` blocks to harden `GITHUB_TOKEN` scope
- Standard CI/PR-validation workflows get `contents: read`
- Lint-pr-name workflow (runs on `pull_request_target`) gets `contents: read` + `pull-requests: write`
- Release workflow gets `contents: write` + `pull-requests: write` (needed by release-please)

Motivated by CVE-2025-30066 — pinning permissions caps token authority if a third-party action is compromised.